### PR TITLE
Update Lambda runtime

### DIFF
--- a/src/scheduled-tasks-template.yml
+++ b/src/scheduled-tasks-template.yml
@@ -143,7 +143,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Timeout: 30
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Role: !GetAtt LambdaRole.Arn
       Environment:
         Variables:


### PR DESCRIPTION
The `nodejs8.10` runtime is [deprecated](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html). 